### PR TITLE
Specified folder exclusion

### DIFF
--- a/lib/dirsum.js
+++ b/lib/dirsum.js
@@ -24,16 +24,24 @@ function _summarize(method, hashes) {
   return obj;
 }
 
-function digest(root, method, callback) {
+function digest(root, method, exclude, callback) {
   if (!root || typeof(root) !== 'string') {
     throw new TypeError('root is required (string)');
   }
+
   if (method) {
     if (typeof(method) === 'string') {
       // NO-OP
+      if(typeof(exclude) === 'function') {
+        callback = exclude;
+        exclude = [];
+      }else if(typeof(exclude) !== 'object'){
+        throw new TypeError('exclude must be an object');
+      }
     } else if (typeof(method) === 'function') {
       callback = method;
       method = 'md5';
+      exclude = [];
     } else {
       throw new TypeError('hash must be a string');
     }
@@ -49,12 +57,20 @@ function digest(root, method, callback) {
   fs.readdir(root, function(err, files) {
     if (err) return callback(err);
 
+    exclude.forEach(function(folder){
+        var index = files.indexOf(folder);
+        if(index != -1){
+            files.splice(index, 1);
+        }
+    });
+    
     if (files.length === 0) {
       return callback(undefined, {hash: '', files: {}});
     }
-
+    
     var hashed = 0;
     files.forEach(function(f) {
+
       var path = root + '/' + f;
       fs.stat(path, function(err, stats) {
         if (err) return callback(err);


### PR DESCRIPTION
Hello!

I needed to get a checksum of a directory, excluding some folders in it when calculating that checksum. So I added a new param 'exclude' to specify folders which will be excluded from calculation of checksum of root directory.
'exclude' is an array and its elements are names of folders which are needed to be excluded.

I guess it might be an useful feature for others as it was in my case.
